### PR TITLE
fix: remove crooked frame but keep the straight frame (#226)

### DIFF
--- a/src/app/our-story/page.tsx
+++ b/src/app/our-story/page.tsx
@@ -148,7 +148,7 @@ export default function OurStory() {
             </div>
 
             <div className="relative">
-              {/* CROOKED FRAME REMOVED HERE */}
+              {/* Crooked frame removed */}
               <div className="relative bg-gradient-to-br from-[#732154]/20 to-[#732154]/30 dark:from-[#732154]/40 dark:to-[#732154]/50 p-8 rounded-3xl shadow-2xl">
                 <Image
                   src="/images/NUP_206704_00566-scaled.jpg"


### PR DESCRIPTION
Removed the crooked purple frame that was present on the "Our Story" page in the "About" section. Here is how the picture now looks with the removal of the crooked frame while keeping the straight one. 

<img width="1919" height="989" alt="Updated Frame" src="https://github.com/user-attachments/assets/ef776e40-92da-440e-81c2-b28e376e2b54" />
