### PR TITLE
Issue #266: Removed 'Orange Book Elana Button' on Our Story Page

### DIFF
--- a/src/app/our-story/page.tsx
+++ b/src/app/our-story/page.tsx
@@ -94,9 +94,6 @@ export default function OurStory() {
         <div className="container mx-auto px-4">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div>
-
-              {/* Removed the FormButton for Issue #266 */}
-
               <h2 className="text-4xl md:text-5xl font-bold mb-8 text-violet-600 dark:text-saffron-400">
                 Elana's Story
               </h2>


### PR DESCRIPTION
Removed the orange button on Our Story page of the website that said "Book Elana to Event".

<img width="1903" height="944" alt="Book Elana Button Removed" src="https://github.com/user-attachments/assets/094c2521-c076-47a6-a0aa-2f5cd82966a5" />
