### PR TITLE
Issue #331: Removed Board Members description text

### DIFF
--- a/src/app/kccf-family/page.tsx
+++ b/src/app/kccf-family/page.tsx
@@ -96,7 +96,6 @@ export default function KCCFFamily() {
             <h2 className="text-4xl md:text-5xl font-bold mb-6 text-violet-600 dark:text-white">
               Board Members
             </h2>
-          
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">


### PR DESCRIPTION
Removed the redundant subtitle under the Board Members title text

Updated Version:
<img width="1905" height="941" alt="image" src="https://github.com/user-attachments/assets/78cc4ad7-2cbd-4bac-8d15-9897c2bea27a" />
