### PR TITLE
Update camper registration form wording and link

### DIFF
--- a/src/contexts/FormModalContext.tsx
+++ b/src/contexts/FormModalContext.tsx
@@ -23,7 +23,7 @@ export const FORM_CONFIGS: Record<FormType, FormConfig> = {
   'camp-camper': {
     title: 'Thank you for your interest in the KCCF Summer Camp 2026.',
     subtitle: 'The form may take a few seconds to load.',
-    src: 'https://forms.monday.com/forms/6d7260392d585e6fd7cb1b13795638ab?r=use1',
+    src: 'https://forms.monday.com/forms/embed/6d7260392d585e6fd7cb1b13795638ab?r=use1',
     height: '1550px'
   },
   'camp-counselor': {

--- a/src/contexts/FormModalContext.tsx
+++ b/src/contexts/FormModalContext.tsx
@@ -21,9 +21,9 @@ interface FormConfig {
 
 export const FORM_CONFIGS: Record<FormType, FormConfig> = {
   'camp-camper': {
-    title: 'Thank you for registering your child for camp!',
+    title: 'Thank you for your interest in the KCCF Summer Camp 2026.',
     subtitle: 'The form may take a few seconds to load.',
-    src: 'https://forms.monday.com/forms/embed/41086441b740b6e179cbde8b574bd794?r=use1',
+    src: 'https://forms.monday.com/forms/6d7260392d585e6fd7cb1b13795638ab?r=use1',
     height: '1550px'
   },
   'camp-counselor': {


### PR DESCRIPTION
Update camper form to new Monday link: https://forms.monday.com/forms/embed/6d7260392d585e6fd7cb1b13795638ab?r=use1