### PR TITLE
feat: Google Ads conversion tracking via gclid passthrough (Zeffy)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
 import ConsentPreferencesModal from "@/components/ConsentPreferencesModal";
 import SubmissionModal from "@/components/SubmissionModal";
 import GoogleTagManager from "@/components/GoogleTagManager";
+import GclidCapture from "@/components/GclidCapture";
 import { Suspense, type ReactNode } from "react";
 import { SearchModalProvider } from "@/contexts/SearchModalContext";
 import SearchModal from "@/components/SearchModal";
@@ -63,6 +64,7 @@ export default function RootLayout({
         <ThemeProvider>
           <CookieConsentProvider>
             <GoogleTagManager />
+            <GclidCapture />
             <SearchModalProvider>
               <DonationModalProvider>
                 <FormModalProvider>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -38,7 +38,7 @@ export default function Privacy() {
           <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-8 md:p-12">
             {/* Last Updated */}
             <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
-              Last Updated: November 2025
+              Last Updated: May 2026
             </p>
 
             {/* Introduction */}
@@ -139,7 +139,7 @@ export default function Privacy() {
                 <div className="bg-platinum-50 dark:bg-gray-700 rounded-lg p-4">
                   <h4 className="font-semibold text-gray-800 dark:text-white mb-2">Marketing Cookies</h4>
                   <p className="text-gray-600 dark:text-gray-300 text-sm">
-                    These cookies are used to track visitors across websites. The intention is to display ads that are relevant and engaging for the individual user and thereby more valuable for publishers and third-party advertisers.
+                    These cookies are used to track visitors across websites. The intention is to display ads that are relevant and engaging for the individual user and thereby more valuable for publishers and third-party advertisers. If you accept marketing cookies and arrive from a Google ad, we store the ad&apos;s click ID (gclid) and pass it through our donation platform (Zeffy) to measure donations as Google Ads conversions, helping us spend our advertising budget responsibly.
                   </p>
                 </div>
               </div>

--- a/src/components/DonationModal.tsx
+++ b/src/components/DonationModal.tsx
@@ -1,11 +1,15 @@
 "use client"
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useDonationModal } from '@/contexts/DonationModalContext'
+import { useCookieConsent } from '@/contexts/CookieConsentContext'
+import { getStoredGclid } from '@/lib/gclid'
 import Spinner from '@/components/Spinner'
+
+const ZEFFY_FORM_URL = 'https://www.zeffy.com/embed/donation-form/donate-to-make-a-difference-18649'
 
 type DonationProvider = 'zeffy' | 'givelively'
 
@@ -79,9 +83,24 @@ function GiveLivelyWidget() {
 
 export default function DonationModal() {
   const { isOpen, closeModal, campaign } = useDonationModal()
+  const { consent } = useCookieConsent()
   const [selectedProvider, setSelectedProvider] = useState<DonationProvider>('zeffy')
   const [iframeLoaded, setIframeLoaded] = useState(false)
   const [isProviderSectionOpen, setIsProviderSectionOpen] = useState(true)
+
+  // Build the Zeffy form URL, carrying the Google Ads gclid (when present and
+  // marketing consent is granted) so the donation can be tied back to the ad
+  // click. Zeffy round-trips UTM params into the donation record + webhook
+  // payload, so the gclid rides along in utm_content; the Zap/automation reads
+  // utm_content back out and sends it to Google Ads offline conversion import.
+  // Recomputed when the modal opens so a gclid captured after first render is
+  // still picked up. Verify with a $1 test donation before relying on it.
+  const zeffyFormUrl = useMemo(() => {
+    if (!isOpen || !consent.marketing) return ZEFFY_FORM_URL
+    const gclid = getStoredGclid()
+    if (!gclid) return ZEFFY_FORM_URL
+    return `${ZEFFY_FORM_URL}?utm_content=${encodeURIComponent(gclid)}`
+  }, [isOpen, consent.marketing])
 
   // Reset iframeLoaded when modal opens or provider changes
   useEffect(() => {
@@ -295,7 +314,7 @@ export default function DonationModal() {
                 )}
                 <iframe
                   className={`block w-full h-full max-w-full border-0 ${!iframeLoaded ? 'opacity-0' : 'opacity-100'}`}
-                  src="https://www.zeffy.com/embed/donation-form/donate-to-make-a-difference-18649"
+                  src={zeffyFormUrl}
                   title="Zeffy donation form"
                   scrolling="yes"
                   allow="payment"

--- a/src/components/GclidCapture.tsx
+++ b/src/components/GclidCapture.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect } from 'react'
+import { useCookieConsent } from '@/contexts/CookieConsentContext'
+import { captureGclidFromUrl } from '@/lib/gclid'
+
+// Captures the Google Ads gclid from the landing URL so DonationModal can pass
+// it through the Zeffy form for conversion attribution. Gated on `marketing`
+// consent to match the site's consent model. Runs on mount and again if the
+// visitor grants marketing consent while still on the landing page (the URL
+// still carries the gclid at that point).
+export default function GclidCapture() {
+  const { consent } = useCookieConsent()
+
+  useEffect(() => {
+    if (consent.marketing) {
+      captureGclidFromUrl()
+    }
+  }, [consent.marketing])
+
+  return null
+}

--- a/src/lib/gclid.ts
+++ b/src/lib/gclid.ts
@@ -1,0 +1,50 @@
+// Utilities for capturing the Google Ads click identifier (gclid) and reading
+// it back when building the Zeffy donation form URL. Passing the gclid through
+// the form lets donations be matched back to the originating ad click via
+// Google Ads offline conversion import (the webhook -> Zapier/Make -> Ads path).
+//
+// Privacy note: a gclid is advertising/measurement data, so capture is gated on
+// the site's `marketing` consent category (see CookieConsentContext). Callers
+// are responsible for checking consent before invoking captureGclidFromUrl().
+
+const STORAGE_KEY = 'kccf.gclid'
+
+// Google Ads' default click-to-conversion window is up to 90 days; keep the
+// stored gclid for the same window so late donations still attribute.
+const GCLID_TTL_MS = 90 * 24 * 60 * 60 * 1000
+
+interface StoredGclid {
+  value: string
+  timestamp: number
+}
+
+/** Read a gclid from the current URL's query string and persist it. */
+export function captureGclidFromUrl(): void {
+  if (typeof window === 'undefined') return
+  try {
+    const gclid = new URLSearchParams(window.location.search).get('gclid')
+    if (!gclid) return
+    const payload: StoredGclid = { value: gclid, timestamp: Date.now() }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // Storage may be unavailable (private mode / blocked); fail silently.
+  }
+}
+
+/** Return a stored, non-expired gclid, or null. */
+export function getStoredGclid(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const stored = JSON.parse(raw) as StoredGclid
+    if (!stored?.value) return null
+    if (Date.now() - stored.timestamp > GCLID_TTL_MS) {
+      localStorage.removeItem(STORAGE_KEY)
+      return null
+    }
+    return stored.value
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## What
Enables Google Ads conversion tracking for donations without a server (static GitHub Pages stays as-is).

Captures the Google Ads click ID (`gclid`) from the landing URL and passes it through the Zeffy donation form as `utm_content`. Zeffy round-trips UTM params into the donation record and webhook payload, so a downstream webhook → Zapier/Make automation can report donations to Google Ads offline conversion import, attributed to the originating ad click.

## Changes
- `src/lib/gclid.ts` — capture/read gclid with a 90-day TTL (matches Ads' click→conversion window)
- `src/components/GclidCapture.tsx` — reads `?gclid=` on landing, **gated on `marketing` consent**; mounted in `layout.tsx`
- `src/components/DonationModal.tsx` — appends `utm_content=<gclid>` to the Zeffy iframe URL when marketing consent is granted
- `src/app/privacy/page.tsx` — discloses the gclid passthrough under Marketing Cookies; bumps Last Updated

## Consent
gclid capture and passthrough only happen when the visitor accepts **marketing** cookies (defaults off), consistent with the site's existing consent model.

## Not in this PR (account config, no code)
- Zeffy webhook → Zapier/Make → Google Ads offline conversion import
- Google Ads conversion action (Import → from clicks)

## Verification still required
Zeffy has no sandbox. Confirm with a **$1 test donation**: visit `/donate?gclid=test123`, accept marketing cookies, donate through the Zeffy modal, confirm `utm_content=test123` appears in the Zeffy donation details / webhook payload, then refund. This validates the one unverified assumption — that Zeffy captures UTM params from the **embedded iframe** src.

## Note on GiveLively
GiveLively only captures `utm_source` (one slot) and gclid passthrough isn't clean there — those donations should be counted via a GA4 Measurement Protocol Zap instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)