### PR TITLE
docs: refresh infra technical debt against current FFC template

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -50,18 +50,18 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 
 | # | Capability | FFC Template (current) | KCCF-web (verified) | Status |
 |---|---|---|---|---|
-| **Testing** |
+| | **Testing** | | | |
 | 1.1 | Unit / component tests (Jest + Testing Library) | ✅ `jest.config.js`, `jest.setup.js`, `__tests__/` | ❌ none | ❌ |
 | 1.2 | Accessibility tests (jest-axe / axe-core) | ✅ `jest-axe`, `@axe-core/react`, `@axe-core/playwright` | ❌ none | ❌ |
 | 1.3 | E2E tests (Playwright) | ✅ `playwright.config.ts`, `tests/` | ❌ none (`@playwright/test` is only a Next.js peer dep) | ❌ |
-| **Formatting & Style** |
+| | **Formatting & Style** | | | |
 | 2.1 | Prettier | ✅ `.prettierrc.json`, `.prettierignore`, `format` + `format:check` | ❌ none | ❌ |
 | 2.2 | EditorConfig | ✅ `.editorconfig` | ❌ | ❌ |
 | 2.3 | Node version pin | ✅ `.nvmrc` | ❌ | ❌ |
-| **Hooks & Commits** |
+| | **Hooks & Commits** | | | |
 | 3.1 | Husky pre-commit hooks | ✅ `.husky/`, `prepare` script | ❌ | ❌ |
 | 3.2 | Commitlint | ✅ `commitlint.config.js` | ❌ | ❌ |
-| **CI/CD** |
+| | **CI/CD** | | | |
 | 4.1 | Split CI vs. deploy workflows | ✅ `ci.yml` + `deploy.yml` | 🟡 single `nextjs.yml` (build+deploy combined) | ❌ |
 | 4.2 | Format check in CI | ✅ `npm run format:check` step | ❌ | ❌ |
 | 4.3 | Lint gate in CI | ✅ | ✅ (lint runs in `nextjs.yml`) | ✅ |
@@ -69,14 +69,14 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 | 4.5 | E2E tests in CI | ✅ Playwright install + `test:e2e` | ❌ | ❌ |
 | 4.6 | Bundle-size check | ✅ `check:bundle` | ❌ | ❌ |
 | 4.7 | Build artifact upload on failure | ✅ | ❌ | ❌ |
-| **Security & Supply Chain** |
+| | **Security & Supply Chain** | | | |
 | 5.1 | CodeQL scanning | ✅ | ✅ `codeql.yml` | ✅ |
 | 5.2 | Dependabot | ✅ `dependabot.yml` | ❌ | ❌ |
 | 5.3 | npm audit in CI | ✅ `security-audit.yml` / `audit:high` | ❌ | ❌ |
 | 5.4 | OpenSSF Scorecard | ✅ `scorecard.yml` | ❌ | ❌ |
 | 5.5 | security.txt + expiry monitor | ✅ `security-txt-expiry.yml` | ❌ | ❌ |
 | 5.6 | Vulnerability disclosure policy page | ✅ `/vulnerability-disclosure-policy` | ❌ | ❌ |
-| **Performance & Monitoring** |
+| | **Performance & Monitoring** | | | |
 | 6.1 | Lighthouse CI | ✅ `lighthouse.yml`, `lighthouserc.json` | ❌ | ❌ |
 | 6.2 | Bundle analyzer | ✅ `analyze` script + `@next/bundle-analyzer` | ❌ | ❌ |
 | 6.3 | Link checking (linkinator) | ✅ `.linkinatorrc.json`, `check-links` | ❌ | ❌ |
@@ -84,7 +84,7 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 | 6.5 | Config-drift check | ✅ `drift-check.yml`, `check:drift` | ❌ | ❌ |
 | 6.6 | Phantom-revert guard | ✅ `phantom-revert-guard.yml` | ❌ | ❌ |
 
-**Score:** KCCF-web meets **2 of 25** tracked infrastructure capabilities (CodeQL, lint-in-CI).
+**Score:** KCCF-web meets **2 of 27** tracked infrastructure capabilities (CodeQL, lint-in-CI).
 
 ---
 
@@ -180,6 +180,9 @@ Snapshot of the reference template as of July 2026 — this is the moving target
 
 ### 4.2 Add Format Check to CI
 - **Target:** `npm run format:check` step (depends on Phase 2.1).
+
+### 4.3 Lint Gate in CI — ✅ **Already satisfied**
+- **Current:** Lint already runs as a gate in `nextjs.yml`. Carry it into the new `ci.yml` unchanged when splitting workflows (Phase 4.1).
 
 ### 4.4 Add Unit Tests to CI
 - **Target:** `npm test` with `CI=true` (depends on Phase 1.1).

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -1,933 +1,277 @@
-# Technical Debt and Backlog
+# Technical Debt and Backlog — Infrastructure & Engineering Maturity
 
-**Document Purpose:** This document tracks technical debt items and improvement opportunities for the KCCF-web project, identified through comparison with the Free For Charity (FFC) Single Page Template repository.
+**Document Purpose:** Tracks the infrastructure / engineering-maturity gap between KCCF-web and the Free For Charity (FFC) Single Page Template, and records KCCF-web's current status against each item.
 
-**Scope:** This document covers internal technical improvements, code quality enhancements, CI/CD optimizations, testing infrastructure, and security controls that will improve maintainability and development velocity.
+**Scope:** Infrastructure only — testing, code formatting, git hooks, CI/CD structure, security & supply-chain controls, and performance/monitoring. Content, copy, and design work is tracked separately and is **not** part of this document.
 
-**Last Updated:** December 2025  
-**Status:** Active Tracking  
-**Repository:** koenig-childhood-cancer-foundation/KCCF-web  
+**Last Updated:** July 2026 (refreshed against the current FFC template)
+**Status:** Active Tracking
+**Repository:** koenig-childhood-cancer-foundation/KCCF-web
 **Reference Repository:** [FreeForCharity/FFC_Single_Page_Template](https://github.com/FreeForCharity/FFC_Single_Page_Template)
+
+> **Verification note (July 2026):** KCCF-web status below was verified directly against the working tree, not assumed. Checks run: file/directory search for `*.test.*`/`*.spec.*` and `__tests__`/`tests`/`e2e`/`cypress` dirs; test-framework config search (jest/vitest/playwright/cypress); `package.json` scripts + devDependencies; `package-lock.json` framework presence; and a grep for test steps across `.github/workflows/`. **Result: zero automated tests of any kind exist in this repository.** The only trace of `@playwright/test` in the lockfile is an *optional peer dependency declared by Next.js itself* (`node_modules/next`) — it is not installed as a direct dependency, has no config, no test files, and is never invoked.
 
 ---
 
 ## Table of Contents
 
-1. [Overview](#overview)
-2. [Phase 1: Testing Infrastructure](#phase-1-testing-infrastructure)
-3. [Phase 2: Code Quality & Developer Experience](#phase-2-code-quality--developer-experience)
-4. [Phase 3: CI/CD Pipeline Enhancements](#phase-3-cicd-pipeline-enhancements)
-5. [Phase 4: Documentation Improvements](#phase-4-documentation-improvements)
-6. [Phase 5: Security & Branch Protection](#phase-5-security--branch-protection)
-7. [Phase 6: Performance & Monitoring](#phase-6-performance--monitoring)
-8. [Tracking and Prioritization](#tracking-and-prioritization)
-9. [Related Documentation](#related-documentation)
+1. [Executive Summary](#executive-summary)
+2. [Status Dashboard](#status-dashboard)
+3. [Verified Current State — KCCF-web](#verified-current-state--kccf-web)
+4. [Current FFC Template Reference](#current-ffc-template-reference)
+5. [Phase 1: Testing Infrastructure](#phase-1-testing-infrastructure)
+6. [Phase 2: Code Formatting & Style](#phase-2-code-formatting--style)
+7. [Phase 3: Git Hooks & Commit Standards](#phase-3-git-hooks--commit-standards)
+8. [Phase 4: CI/CD Pipeline Restructure](#phase-4-cicd-pipeline-restructure)
+9. [Phase 5: Security & Supply Chain](#phase-5-security--supply-chain)
+10. [Phase 6: Performance & Monitoring](#phase-6-performance--monitoring)
+11. [Recommended Sequencing](#recommended-sequencing)
+12. [Intentional Differences from FFC](#intentional-differences-from-ffc)
+13. [Related Documentation](#related-documentation)
 
 ---
 
-## Overview
+## Executive Summary
 
-This document identifies technical improvements by comparing KCCF-web with the FFC Single Page Template. Items are organized into **phases** for structured implementation, allowing the team to tackle improvements incrementally without overwhelming the development process.
+KCCF-web is **actively maintained on content and product**, but its **infrastructure/engineering-maturity is essentially at the pre-audit baseline**. Since the original December 2025 comparison, **none** of the identified infrastructure items have been adopted, while the FFC template itself has advanced further — adding a security & governance layer (OpenSSF Scorecard, security-audit, security.txt lifecycle, drift/uptime/revert-guard workflows) and accessibility testing (jest-axe, axe-core) that the original document did not track.
 
-**Total Identified Items:** 35+ improvement opportunities across 6 phases
+**Net effect: the gap has widened, not narrowed.**
 
-**Current Repository Status:**
-- ✅ Next.js 15 with App Router
-- ✅ TypeScript with type checking
-- ✅ ESLint for code quality
-- ✅ CodeQL security scanning
-- ✅ Basic CI/CD with GitHub Actions
-- ✅ GitHub Pages deployment
-- ⚠️ No automated tests
-- ⚠️ No code formatting enforcement
-- ⚠️ No pre-commit hooks
-- ⚠️ Limited documentation for development processes
+- **Infrastructure adoption vs. plan:** ~0%
+- **Automated tests in KCCF-web:** 0 (verified)
+- **CI jobs in KCCF-web:** build/deploy + CodeQL only (no format, lint-as-gate is present, no tests, no audit, no perf)
+- **Config/quality files adopted:** 0 of ~10
+
+---
+
+## Status Dashboard
+
+Legend: ✅ done · 🟡 partial · ❌ not started
+
+| # | Capability | FFC Template (current) | KCCF-web (verified) | Status |
+|---|---|---|---|---|
+| **Testing** |
+| 1.1 | Unit / component tests (Jest + Testing Library) | ✅ `jest.config.js`, `jest.setup.js`, `__tests__/` | ❌ none | ❌ |
+| 1.2 | Accessibility tests (jest-axe / axe-core) | ✅ `jest-axe`, `@axe-core/react`, `@axe-core/playwright` | ❌ none | ❌ |
+| 1.3 | E2E tests (Playwright) | ✅ `playwright.config.ts`, `tests/` | ❌ none (`@playwright/test` is only a Next.js peer dep) | ❌ |
+| **Formatting & Style** |
+| 2.1 | Prettier | ✅ `.prettierrc.json`, `.prettierignore`, `format` + `format:check` | ❌ none | ❌ |
+| 2.2 | EditorConfig | ✅ `.editorconfig` | ❌ | ❌ |
+| 2.3 | Node version pin | ✅ `.nvmrc` | ❌ | ❌ |
+| **Hooks & Commits** |
+| 3.1 | Husky pre-commit hooks | ✅ `.husky/`, `prepare` script | ❌ | ❌ |
+| 3.2 | Commitlint | ✅ `commitlint.config.js` | ❌ | ❌ |
+| **CI/CD** |
+| 4.1 | Split CI vs. deploy workflows | ✅ `ci.yml` + `deploy.yml` | 🟡 single `nextjs.yml` (build+deploy combined) | ❌ |
+| 4.2 | Format check in CI | ✅ `npm run format:check` step | ❌ | ❌ |
+| 4.3 | Lint gate in CI | ✅ | ✅ (lint runs in `nextjs.yml`) | ✅ |
+| 4.4 | Unit tests in CI | ✅ `npm test` (CI=true) | ❌ | ❌ |
+| 4.5 | E2E tests in CI | ✅ Playwright install + `test:e2e` | ❌ | ❌ |
+| 4.6 | Bundle-size check | ✅ `check:bundle` | ❌ | ❌ |
+| 4.7 | Build artifact upload on failure | ✅ | ❌ | ❌ |
+| **Security & Supply Chain** |
+| 5.1 | CodeQL scanning | ✅ | ✅ `codeql.yml` | ✅ |
+| 5.2 | Dependabot | ✅ `dependabot.yml` | ❌ | ❌ |
+| 5.3 | npm audit in CI | ✅ `security-audit.yml` / `audit:high` | ❌ | ❌ |
+| 5.4 | OpenSSF Scorecard | ✅ `scorecard.yml` | ❌ | ❌ |
+| 5.5 | security.txt + expiry monitor | ✅ `security-txt-expiry.yml` | ❌ | ❌ |
+| 5.6 | Vulnerability disclosure policy page | ✅ `/vulnerability-disclosure-policy` | ❌ | ❌ |
+| **Performance & Monitoring** |
+| 6.1 | Lighthouse CI | ✅ `lighthouse.yml`, `lighthouserc.json` | ❌ | ❌ |
+| 6.2 | Bundle analyzer | ✅ `analyze` script + `@next/bundle-analyzer` | ❌ | ❌ |
+| 6.3 | Link checking (linkinator) | ✅ `.linkinatorrc.json`, `check-links` | ❌ | ❌ |
+| 6.4 | Uptime monitoring workflow | ✅ `uptime.yml` | ❌ | ❌ |
+| 6.5 | Config-drift check | ✅ `drift-check.yml`, `check:drift` | ❌ | ❌ |
+| 6.6 | Phantom-revert guard | ✅ `phantom-revert-guard.yml` | ❌ | ❌ |
+
+**Score:** KCCF-web meets **2 of 25** tracked infrastructure capabilities (CodeQL, lint-in-CI).
+
+---
+
+## Verified Current State — KCCF-web
+
+**`package.json` scripts (6):** `dev`, `build`, `export`, `preview`, `start`, `lint` — no `test`, no `format`.
+
+**`package.json` devDependencies:** `@eslint/eslintrc`, `@tailwindcss/postcss`, `@types/*`, `eslint`, `eslint-config-next`, `tailwindcss`, `typescript`. No test, formatting, hook, or commit-lint tooling.
+
+**`.github/workflows/` (2 files):**
+- `nextjs.yml` — lint → type-check (via build) → build → deploy to GitHub Pages (single combined workflow)
+- `codeql.yml` — CodeQL security scanning
+
+**Quality/config files present:** none of `.prettierrc*`, `.editorconfig`, `.nvmrc`, `jest.config.js`, `playwright.config.ts`, `commitlint.config.js`, `.husky/`, `dependabot.yml`, `lighthouserc.json`, `.linkinatorrc.json`.
+
+**Tests:** none (verified across files, dirs, configs, deps, scripts, and CI).
+
+---
+
+## Current FFC Template Reference
+
+Snapshot of the reference template as of July 2026 — this is the moving target KCCF-web is measured against.
+
+**Scripts (~20):** `dev`, `build`, `preview`, `analyze`, `lint`, `format`, `format:check`, `test`, `test:watch`, `test:coverage`, `test:e2e`, `test:e2e:ui`, `test:e2e:headed`, `check-links`, `check:drift`, `check:rebrand`, `check:bundle`, `smoke`, `audit:high`, `prepare`.
+
+**Key devDependencies (~29):** Playwright ~1.61, Jest ~30, `@testing-library/*`, `jest-axe`, `@axe-core/react`, `@axe-core/playwright`, Prettier ~3.9, Husky ~9.1, Commitlint ~20.5, `@lhci/cli` ~0.15, `@next/bundle-analyzer`, `linkinator` ~7.6.
+
+**Workflows (9):** `ci.yml`, `deploy.yml`, `drift-check.yml`, `lighthouse.yml`, `phantom-revert-guard.yml`, `scorecard.yml`, `security-audit.yml`, `security-txt-expiry.yml`, `uptime.yml`.
+
+**`ci.yml` job shape:** checkout → Node 20 → `npm ci` → `format:check` → `lint` → `npm test` (CI=true) → install Playwright chromium → `build` → `check:bundle` → `test:e2e` → upload artifacts on failure. Plus a soft-fail link-check job (`check-links`).
 
 ---
 
 ## Phase 1: Testing Infrastructure
 
-**Priority:** 🔴 High  
-**Estimated Effort:** 2-3 weeks  
-**Impact:** Catches bugs early, prevents regressions, improves code confidence
+**Priority:** 🔴 High · **Impact:** Catches regressions before deploy; this is the single largest gap.
 
-### 1.1 Unit Testing Framework
+### 1.1 Unit / Component Testing (Jest + React Testing Library)
+- **Current:** No unit tests exist (verified).
+- **Target:** Jest + `@testing-library/react` with a baseline suite on `Navigation`, `Footer`, `CookieConsentBanner`, `FormModal`.
+- **Steps:** add `jest`, `jest-environment-jsdom`, `@testing-library/{react,jest-dom,user-event}`; add `jest.config.js` + `jest.setup.js`; add `test`, `test:watch`, `test:coverage` scripts; create `__tests__/`.
+- **Reference:** FFC `jest.config.js`, `jest.setup.js`, `__tests__/`.
 
-**Current State:** No unit tests exist  
-**Target State:** Jest + React Testing Library with baseline coverage
+### 1.2 Accessibility Testing (NEW vs. Dec-2025 doc)
+- **Current:** None.
+- **Target:** `jest-axe` assertions in component tests and `@axe-core/playwright` in E2E — enforces WCAG basics automatically.
+- **Reference:** FFC `jest-axe`, `@axe-core/react`, `@axe-core/playwright`.
 
-**Implementation Steps:**
-
-1. **Install Testing Dependencies**
-   ```bash
-   npm install --save-dev jest jest-environment-jsdom @testing-library/react @testing-library/jest-dom @testing-library/user-event
-   ```
-
-2. **Create Configuration Files**
-   - `jest.config.js` - Jest configuration (see FFC template)
-   - `jest.setup.js` - Test environment setup
-   - Add test scripts to `package.json`:
-     ```json
-     "test": "jest",
-     "test:watch": "jest --watch",
-     "test:coverage": "jest --coverage"
-     ```
-
-3. **Create Test Directory Structure**
-   ```
-   __tests__/
-   ├── components/
-   │   ├── Navigation.test.tsx
-   │   ├── Footer.test.tsx
-   │   └── CookieConsentBanner.test.tsx
-   └── lib/
-       └── (utility tests as needed)
-   ```
-
-4. **Initial Test Coverage Target:** 5-10% (baseline)
-   - Focus on critical components: Navigation, Footer, Cookie Consent
-   - Test user interactions and accessibility
-
-**Reference:** FFC template files:
-- `.github/workflows/ci.yml` (unit test execution)
-- `jest.config.js`
-- `jest.setup.js`
-- `__tests__/` directory
+### 1.3 E2E Testing (Playwright)
+- **Current:** None. (`@playwright/test` in the lockfile is a Next.js optional peer dep, not a configured suite.)
+- **Target:** `playwright.config.ts` + `tests/` covering nav, donation modal, form modals, dark-mode toggle, and GitHub Pages base-path image loading; scripts `test:e2e`, `test:e2e:ui`, `test:e2e:headed`.
+- **Reference:** FFC `playwright.config.ts`, `tests/`.
 
 ---
 
-### 1.2 End-to-End Testing (Playwright)
+## Phase 2: Code Formatting & Style
 
-**Current State:** No E2E tests  
-**Target State:** Playwright tests for critical user flows
+**Priority:** 🟠 Medium · **Impact:** Consistent style, smaller diffs, less review friction.
 
-**Implementation Steps:**
+### 2.1 Prettier
+- **Current:** None.
+- **Target:** `.prettierrc.json` + `.prettierignore`; `format` and `format:check` scripts; `format:check` wired into CI (Phase 4.2).
+- **Reference:** FFC `.prettierrc.json`, `.prettierignore`.
 
-1. **Install Playwright**
-   ```bash
-   npm install --save-dev @playwright/test
-   npx playwright install chromium
-   ```
+### 2.2 EditorConfig
+- **Current:** None. **Target:** `.editorconfig` for cross-editor consistency. *(Optional if Prettier is adopted — see intentional differences.)*
 
-2. **Create Configuration**
-   - `playwright.config.ts` - Playwright configuration (see FFC template)
-   - Add test scripts to `package.json`:
-     ```json
-     "test:e2e": "playwright test",
-     "test:e2e:ui": "playwright test --ui",
-     "test:e2e:headed": "playwright test --headed"
-     ```
-
-3. **Create Test Suite**
-   ```
-   tests/
-   ├── navigation.spec.ts
-   ├── forms.spec.ts
-   ├── donation-flow.spec.ts
-   └── github-pages.spec.ts
-   ```
-
-4. **Critical Test Scenarios:**
-   - Navigation menu functionality (mobile and desktop)
-   - Form modal opening and display
-   - Donation modal functionality
-   - Cookie consent flow
-   - Dark mode toggle
-   - GitHub Pages deployment compatibility (image loading)
-
-**Reference:** FFC template files:
-- `playwright.config.ts`
-- `tests/` directory
-- `.github/workflows/ci.yml` (E2E test execution)
+### 2.3 Node Version Pin
+- **Current:** None. **Target:** `.nvmrc` pinned to Node 20 to match CI. **Reference:** FFC `.nvmrc`.
 
 ---
 
-### 1.3 Accessibility Testing
+## Phase 3: Git Hooks & Commit Standards
 
-**Current State:** No automated accessibility testing  
-**Target State:** jest-axe integration for WCAG 2.1 compliance
+**Priority:** 🟠 Medium · **Impact:** Catches issues before they reach CI.
 
-**Implementation Steps:**
+### 3.1 Husky Pre-commit Hooks
+- **Current:** None. **Target:** `.husky/` running lint + format (+ optionally related tests) on commit; `prepare` script. **Reference:** FFC `.husky/`.
 
-1. **Install jest-axe**
-   ```bash
-   npm install --save-dev jest-axe
-   ```
-
-2. **Update jest.setup.js**
-   ```typescript
-   import { toHaveNoViolations } from 'jest-axe';
-   
-   expect.extend(toHaveNoViolations);
-   ```
-
-3. **Add Accessibility Tests**
-   - Include axe checks in all component tests
-   - Test for: button/link labels, color contrast, ARIA attributes, keyboard navigation
-
-**Benefits:**
-- Ensures site is accessible to all users
-- Catches accessibility issues in development
-- Helps meet legal compliance requirements
-
-**Reference:** FFC template `jest.setup.js` and component test files
+### 3.2 Commitlint
+- **Current:** None. **Target:** `commitlint.config.js` enforcing Conventional Commits via a `commit-msg` hook. **Reference:** FFC `commitlint.config.js`.
 
 ---
 
-### 1.4 CI Integration for Tests
+## Phase 4: CI/CD Pipeline Restructure
 
-**Current State:** Tests not run in CI (no tests exist)  
-**Target State:** All tests run automatically on PRs and pushes
+**Priority:** 🔴 High · **Impact:** Real quality gate before deploy; today only lint + build gate deploys.
 
-**Implementation Steps:**
+### 4.1 Split CI and Deploy Workflows
+- **Current:** Single `nextjs.yml` combines build + deploy.
+- **Target:** `ci.yml` (checks, runs on all PRs, no deploy) + `deploy.yml` (deploy on `main` after CI passes).
+- **Reference:** FFC `ci.yml`, `deploy.yml`.
 
-1. **Update `.github/workflows/nextjs.yml`** to include:
-   - Unit test execution (`npm test`)
-   - E2E test execution (`npm run test:e2e`)
-   - Test failure blocks merge
+### 4.2 Add Format Check to CI
+- **Target:** `npm run format:check` step (depends on Phase 2.1).
 
-2. **Add Test Coverage Reporting** (optional Phase 1.5)
-   - Upload coverage reports to artifacts
-   - Display coverage in PR comments (future enhancement)
+### 4.4 Add Unit Tests to CI
+- **Target:** `npm test` with `CI=true` (depends on Phase 1.1).
 
-**Reference:** FFC template `.github/workflows/ci.yml`
+### 4.5 Add E2E Tests to CI
+- **Target:** `npx playwright install --with-deps chromium` → `npm run test:e2e` (depends on Phase 1.3).
 
----
+### 4.6 Bundle-size Check
+- **Target:** `check:bundle` step to catch bundle bloat. **Reference:** FFC `check:bundle`.
 
-## Phase 2: Code Quality & Developer Experience
-
-**Priority:** 🟡 Medium-High  
-**Estimated Effort:** 1-2 weeks  
-**Impact:** Consistent code style, faster development, fewer code review nitpicks
-
-### 2.1 Prettier Code Formatting
-
-**Current State:** No automated code formatting  
-**Target State:** Prettier enforces consistent code style
-
-**Implementation Steps:**
-
-1. **Install Prettier**
-   ```bash
-   npm install --save-dev prettier
-   ```
-
-2. **Create Configuration Files**
-   - `.prettierrc.json`:
-     ```json
-     {
-       "semi": false,
-       "singleQuote": true,
-       "trailingComma": "es5",
-       "tabWidth": 2,
-       "printWidth": 100,
-       "arrowParens": "always",
-       "endOfLine": "lf"
-     }
-     ```
-   - `.prettierignore`:
-     ```
-     .next
-     out
-     node_modules
-     package-lock.json
-     ```
-
-3. **Add Scripts to package.json**
-   ```json
-   "format": "prettier --write .",
-   "format:check": "prettier --check ."
-   ```
-
-4. **Format Entire Codebase**
-   ```bash
-   npm run format
-   ```
-
-**Benefits:**
-- Eliminates style debates in code reviews
-- Consistent code style across all files
-- Automatic fixing reduces manual work
-
-**Reference:** FFC template `.prettierrc.json`, `.prettierignore`
+### 4.7 Upload Build Artifacts on Failure
+- **Target:** Upload `.next/` / `out/` on failed runs for debugging.
 
 ---
 
-### 2.2 Husky Pre-commit Hooks
+## Phase 5: Security & Supply Chain
 
-**Current State:** No pre-commit validation  
-**Target State:** Automated checks before every commit
+**Priority:** 🔴 High · **Impact:** Vulnerability detection and supply-chain hardening.
 
-**Implementation Steps:**
+### 5.1 CodeQL — ✅ **Already done** (`codeql.yml`).
 
-1. **Install Husky**
-   ```bash
-   npm install --save-dev husky
-   ```
+### 5.2 Dependabot
+- **Current:** None. **Target:** `.github/dependabot.yml` for npm + GitHub Actions, grouped updates. **Reference:** FFC `dependabot.yml`.
 
-2. **Initialize Husky**
-   ```bash
-   npx husky init
-   ```
+### 5.3 npm Audit in CI
+- **Current:** None. **Target:** `security-audit.yml` / `audit:high` failing on high-severity advisories. **Reference:** FFC `security-audit.yml`.
 
-3. **Create Pre-commit Hook** (`.husky/pre-commit`):
-   ```bash
-   #!/bin/sh
-   # Run formatting check first
-   npm run format:check || {
-     echo "❌ Code formatting issues detected. Please run 'npm run format' to fix."
-     exit 1
-   }
-   
-   # Run linting
-   npm run lint || {
-     echo "❌ Linting errors detected. Please fix the errors and try again."
-     exit 1
-   }
-   
-   echo "✅ Pre-commit checks passed!"
-   ```
+### 5.4 OpenSSF Scorecard (NEW)
+- **Current:** None. **Target:** `scorecard.yml` publishing a supply-chain security score. **Reference:** FFC `scorecard.yml`.
 
-4. **Add prepare script to package.json**
-   ```json
-   "prepare": "husky"
-   ```
+### 5.5 security.txt + Expiry Monitor (NEW)
+- **Current:** None. **Target:** `/.well-known/security.txt` plus `security-txt-expiry.yml` to alert before it expires. **Reference:** FFC `security-txt-expiry.yml`.
 
-**Benefits:**
-- Catches issues before they're committed
-- Ensures all commits meet quality standards
-- Reduces CI failures
-
-**Reference:** FFC template `.husky/` directory
-
----
-
-### 2.3 Commitlint (Conventional Commits)
-
-**Current State:** Inconsistent commit message formats  
-**Target State:** Enforced conventional commit format
-
-**Implementation Steps:**
-
-1. **Install Commitlint**
-   ```bash
-   npm install --save-dev @commitlint/config-conventional @commitlint/cli
-   ```
-
-2. **Create Configuration** (`commitlint.config.js`):
-   ```javascript
-   module.exports = {
-     extends: ['@commitlint/config-conventional'],
-     rules: {
-       'type-enum': [
-         2,
-         'always',
-         [
-           'feat', 'fix', 'docs', 'style', 'refactor',
-           'test', 'chore', 'perf', 'ci', 'revert'
-         ],
-       ],
-     },
-   }
-   ```
-
-3. **Create Commit-msg Hook** (`.husky/commit-msg`):
-   ```bash
-   #!/bin/sh
-   npx --no -- commitlint --edit $1
-   ```
-
-**Benefits:**
-- Consistent commit history
-- Easier to generate changelogs
-- Clear communication of change types
-
-**Reference:** FFC template `commitlint.config.js`, `.husky/commit-msg`
-
----
-
-### 2.4 Enhanced Code Quality Documentation
-
-**Current State:** Basic CONTRIBUTING.md  
-**Target State:** Comprehensive CODE_QUALITY.md guide
-
-**Implementation Steps:**
-
-1. **Create CODE_QUALITY.md** covering:
-   - Code quality tools and how to use them
-   - TypeScript standards and best practices
-   - Testing standards and requirements
-   - Code review guidelines
-   - Performance standards
-   - Security standards
-
-**Reference:** FFC template `CODE_QUALITY.md`
-
----
-
-## Phase 3: CI/CD Pipeline Enhancements
-
-**Priority:** 🟡 Medium  
-**Estimated Effort:** 1 week  
-**Impact:** Faster feedback, better separation of concerns, improved reliability
-
-### 3.1 Separate CI and Deploy Workflows
-
-**Current State:** Single workflow handles both CI and deployment  
-**Target State:** Separate workflows for CI checks and deployment
-
-**Implementation Steps:**
-
-1. **Create `ci.yml` Workflow**
-   - Runs on all PRs and pushes to main
-   - Includes: format check, lint, unit tests, E2E tests, build
-   - No deployment step
-   - Fast feedback (CI-only)
-
-2. **Create `deploy.yml` Workflow**
-   - Triggered by successful CI workflow completion
-   - Only runs on main branch
-   - Builds with GitHub Pages basePath
-   - Deploys to GitHub Pages
-
-3. **Benefits of Separation:**
-   - Faster PR feedback (no deployment overhead)
-   - Clearer workflow purposes
-   - Can run CI multiple times without deploying
-   - Deployment only happens after all checks pass
-
-**Reference:** FFC template `.github/workflows/ci.yml` and `.github/workflows/deploy.yml`
-
-**Current File to Refactor:** `.github/workflows/nextjs.yml`
-
----
-
-### 3.2 Dependabot Configuration
-
-**Current State:** No automated dependency management  
-**Target State:** Weekly automated dependency update PRs
-
-**Implementation Steps:**
-
-1. **Create `.github/dependabot.yml`**:
-   ```yaml
-   version: 2
-   updates:
-     # npm dependencies
-     - package-ecosystem: 'npm'
-       directory: '/'
-       schedule:
-         interval: 'weekly'
-         day: 'monday'
-         time: '09:00'
-       open-pull-requests-limit: 10
-       commit-message:
-         prefix: 'npm'
-         include: 'scope'
-       labels:
-         - 'dependencies'
-         - 'npm'
-       groups:
-         production-dependencies:
-           dependency-type: 'production'
-           update-types: ['minor', 'patch']
-         development-dependencies:
-           dependency-type: 'development'
-           update-types: ['minor', 'patch']
-     
-     # GitHub Actions
-     - package-ecosystem: 'github-actions'
-       directory: '/'
-       schedule:
-         interval: 'weekly'
-         day: 'monday'
-         time: '09:00'
-       open-pull-requests-limit: 5
-       commit-message:
-         prefix: 'ci'
-       labels:
-         - 'dependencies'
-         - 'github-actions'
-   ```
-
-2. **Enable in Repository Settings**
-   - Settings → Security & Analysis → Dependabot alerts (enable)
-   - Settings → Security & Analysis → Dependabot security updates (enable)
-
-**Benefits:**
-- Automated dependency updates
-- Security vulnerability notifications
-- Grouped updates for easier review
-- Reduced technical debt from outdated dependencies
-
-**Reference:** FFC template `.github/dependabot.yml`
-
----
-
-### 3.3 Improved Cache Strategy
-
-**Current State:** Basic Next.js cache  
-**Target State:** Optimized caching for faster builds
-
-**Implementation Steps:**
-
-1. **Update Cache Configuration** in workflows:
-   ```yaml
-   - name: Restore Next.js cache
-     uses: actions/cache@v4
-     with:
-       path: |
-         .next/cache
-       key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx') }}
-       restore-keys: |
-         ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-   ```
-
-2. **Cache Playwright Browsers** (if applicable)
-
-**Reference:** FFC template `.github/workflows/deploy.yml`
-
----
-
-## Phase 4: Documentation Improvements
-
-**Priority:** 🟢 Low-Medium  
-**Estimated Effort:** 1-2 weeks  
-**Impact:** Better onboarding, clearer processes, reduced questions
-
-### 4.1 Comprehensive Testing Guide
-
-**Current State:** No testing documentation  
-**Target State:** Complete TESTING.md guide
-
-**Implementation Steps:**
-
-1. **Create TESTING.md** covering:
-   - Quick test checklist
-   - Automated test suite overview
-   - Unit testing guide (Jest)
-   - E2E testing guide (Playwright)
-   - Accessibility testing guide
-   - Running tests locally and in CI
-   - Writing new tests
-   - Security testing (CodeQL, npm audit)
-   - Test coverage requirements
-
-**Reference:** FFC template `TESTING.md`
-
----
-
-### 4.2 Dependabot Usage Guide
-
-**Current State:** No Dependabot documentation  
-**Target State:** DEPENDABOT.md guide
-
-**Implementation Steps:**
-
-1. **Create DEPENDABOT.md** covering:
-   - Overview of Dependabot components
-   - Features enabled
-   - Configuration file explanation
-   - Working with Dependabot PRs
-   - Best practices
-   - Troubleshooting
-
-**Reference:** FFC template `DEPENDABOT.md`
-
----
-
-### 4.3 Enhanced Contributing Guide
-
-**Current State:** Good CONTRIBUTING.md exists  
-**Target State:** Enhanced with code quality sections
-
-**Implementation Steps:**
-
-1. **Add to CONTRIBUTING.md:**
-   - Pre-commit hook setup instructions
-   - Commit message format requirements
-   - Code formatting guidelines
-   - Testing requirements before PR
-   - Local testing workflow
-
-**Reference:** FFC template `CONTRIBUTING.md` sections on code quality
-
----
-
-### 4.4 Community Health Files
-
-**Current State:** Basic CODE_OF_CONDUCT, SECURITY, SUPPORT missing  
-**Target State:** Complete community health files
-
-**Implementation Steps:**
-
-1. **Create/Enhance Files:**
-   - `CODE_OF_CONDUCT.md` - Community standards
-   - Update `SECURITY.md` - Expand with threat model, vulnerability response
-   - `SUPPORT.md` - Where to get help
-   - `.github/CODEOWNERS` - Code ownership
-   - `.github/FUNDING.yml` - Donation links
-
-**Reference:** FFC template community health files
-
----
-
-## Phase 5: Security & Branch Protection
-
-**Priority:** 🔴 High (Security), 🟡 Medium (Branch Protection)  
-**Estimated Effort:** 1 week (setup), ongoing (maintenance)  
-**Impact:** Improved security posture, protected main branch
-
-### 5.1 Enhanced Security Documentation
-
-**Current State:** Basic SECURITY.md  
-**Target State:** Comprehensive security documentation
-
-**Implementation Steps:**
-
-1. **Expand SECURITY.md** to include:
-   - Branch protection rules explanation
-   - Required status checks
-   - Security best practices for developers
-   - Working with protected branches
-   - Common issues and solutions
-   - Known vulnerabilities tracking
-   - Security monitoring process
-
-**Reference:** FFC template `SECURITY.md`
-
----
-
-### 5.2 Branch Protection Rules
-
-**Current State:** Unknown protection status  
-**Target State:** Protected main branch with required checks
-
-**Implementation Steps:**
-
-1. **Enable Branch Protection** (Settings → Branches → Add rule for `main`):
-   - ✅ Require a pull request before merging
-   - ✅ Require status checks to pass:
-     - CI workflow
-     - CodeQL scanning
-   - ✅ Require signed commits (recommended)
-   - ✅ Block force pushes
-   - ✅ Restrict deletions
-
-2. **Document Rules** in SECURITY.md
-
-**Benefits:**
-- Prevents direct pushes to main
-- Ensures all code is reviewed
-- Blocks merges until tests pass
-- Maintains clean commit history
-
-**Reference:** FFC template `SECURITY.md` branch protection section
-
----
-
-### 5.3 GitHub Security Features
-
-**Current State:** CodeQL enabled  
-**Target State:** All relevant security features enabled
-
-**Implementation Steps:**
-
-1. **Verify Enabled** (Settings → Security & Analysis):
-   - ✅ Dependency graph
-   - ✅ Dependabot alerts
-   - ✅ Dependabot security updates
-   - ✅ Code scanning (CodeQL)
-
-2. **Configure Secret Scanning** (if available for public repos)
-
----
-
-### 5.4 npm Audit in CI
-
-**Current State:** No npm audit checks in CI  
-**Target State:** Automated security checks for dependencies
-
-**Implementation Steps:**
-
-1. **Add to CI Workflow**:
-   ```yaml
-   - name: Security audit
-     run: npm audit --audit-level=moderate
-   ```
-
-2. **Set Failure Threshold:** Fail on moderate or higher severity
-
-**Benefits:**
-- Early detection of vulnerable dependencies
-- Blocks merges with known vulnerabilities
+### 5.6 Vulnerability Disclosure Policy Page (NEW)
+- **Current:** None (KCCF has `SECURITY.md` but no public policy page). **Target:** a `/vulnerability-disclosure-policy` route mirroring the template.
 
 ---
 
 ## Phase 6: Performance & Monitoring
 
-**Priority:** 🟢 Low  
-**Estimated Effort:** 1-2 weeks  
-**Impact:** Performance tracking, regression prevention
+**Priority:** 🟢 Low–Medium · **Impact:** Regression tracking and availability.
 
-### 6.1 Lighthouse CI Integration
+### 6.1 Lighthouse CI
+- **Target:** `@lhci/cli` + `lighthouserc.json` asserting perf/a11y/best-practices/SEO thresholds; `lighthouse.yml` on PRs. **Reference:** FFC `lighthouse.yml`, `lighthouserc.json`.
 
-**Current State:** No automated performance testing  
-**Target State:** Lighthouse CI runs on PRs and deployments
+### 6.2 Bundle Analyzer
+- **Target:** `@next/bundle-analyzer` + `analyze` script.
 
-**Implementation Steps:**
+### 6.3 Link Checking
+- **Target:** `linkinator` + `.linkinatorrc.json` + `check-links` (soft-fail CI job). **Reference:** FFC `.linkinatorrc.json`.
 
-1. **Install Lighthouse CI**
-   ```bash
-   npm install --save-dev @lhci/cli
-   ```
+### 6.4 Uptime Monitoring (NEW)
+- **Target:** `uptime.yml` pinging production on a schedule. **Reference:** FFC `uptime.yml`.
 
-2. **Create Configuration** (`lighthouserc.json`):
-   ```json
-   {
-     "ci": {
-       "collect": {
-         "staticDistDir": "./out",
-         "numberOfRuns": 3,
-         "url": [
-           "http://localhost/index.html",
-           "http://localhost/donate/index.html"
-         ]
-       },
-       "assert": {
-         "preset": "lighthouse:recommended",
-         "assertions": {
-           "categories:performance": ["warn", {"minScore": 0.6}],
-           "categories:accessibility": ["warn", {"minScore": 0.8}],
-           "categories:best-practices": ["warn", {"minScore": 0.8}],
-           "categories:seo": ["warn", {"minScore": 0.9}]
-         }
-       },
-       "upload": {
-         "target": "temporary-public-storage"
-       }
-     }
-   }
-   ```
+### 6.5 Config-Drift Check (NEW)
+- **Target:** `drift-check.yml` / `check:drift` detecting divergence from template-managed config. **Reference:** FFC `drift-check.yml`.
 
-3. **Create Workflow** (`.github/workflows/lighthouse.yml`):
-   - Runs after deployment
-   - Runs on PRs
-   - Posts results to PR comments
-   - Uploads HTML reports
-
-**Benefits:**
-- Tracks performance over time
-- Catches performance regressions
-- Ensures accessibility standards
-- SEO optimization monitoring
-
-**Reference:** FFC template `.github/workflows/lighthouse.yml`, `lighthouserc.json`
+### 6.6 Phantom-Revert Guard (NEW)
+- **Target:** `phantom-revert-guard.yml` guarding against accidental reversions of key files. **Reference:** FFC `phantom-revert-guard.yml`.
 
 ---
 
-### 6.2 Bundle Size Monitoring
+## Recommended Sequencing
 
-**Current State:** No bundle size tracking  
-**Target State:** Monitor and alert on bundle size growth
+Highest value per unit of effort, low-risk first:
 
-**Implementation Steps:**
-
-1. **Add Bundle Analysis** (optional):
-   ```bash
-   npm install --save-dev @next/bundle-analyzer
-   ```
-
-2. **Track First Load JS** in build output
-
-3. **Measure Current Bundle Size:**
-   - Run the build process and record the size of the main bundle(s) (e.g., using `@next/bundle-analyzer` or similar tools).
-
-4. **Set Budget Thresholds Based on Baseline:**
-   - Target: Set an initial target slightly below the current measured size to encourage optimization.
-   - Maximum: Set a hard limit (e.g., 20% above current size) to prevent uncontrolled growth.
-   - Example (to be updated after measurement):  
-     - Target: < 500KB  
-     - Maximum: < 1MB
-
-**Reference:** FFC template performance documentation
+1. **Quick wins (hours):** `.nvmrc`, `.prettierrc.json` + `format`/`format:check`, `dependabot.yml`. Zero behavioral risk.
+2. **CI gate (½–1 day):** split `nextjs.yml` → `ci.yml` + `deploy.yml`; add `format:check` + `npm audit` steps.
+3. **Testing baseline (2–3 days):** Jest + Testing Library + jest-axe; 3–4 component tests; wire `npm test` into CI.
+4. **E2E + perf (2–3 days):** Playwright smoke suite; Lighthouse CI; linkinator.
+5. **Security/governance layer (1–2 days):** Scorecard, security.txt + expiry monitor, vulnerability-disclosure page, Husky + commitlint.
+6. **Monitoring niceties:** uptime, drift-check, phantom-revert-guard.
 
 ---
 
-### 6.3 Link Validation
+## Intentional Differences from FFC
 
-**Current State:** No automated link checking  
-**Target State:** Validate internal and external links
+These template items are **not** recommended for KCCF-web:
 
-**Implementation Steps:**
-
-1. **Install Linkinator**
-   ```bash
-   npm install --save-dev linkinator
-   ```
-
-2. **Create Configuration** (`.linkinatorrc.json`):
-   ```json
-   {
-     "skip": "^(?!http://localhost)",
-     "recurse": true,
-     "timeout": 5000,
-     "retry": true
-   }
-   ```
-
-3. **Add Script to package.json**
-   ```json
-   "check-links": "linkinator ./out --recurse --config .linkinatorrc.json"
-   ```
-
-**Benefits:**
-- Prevents broken links
-- Validates external resources
-- Improves user experience
-
-**Reference:** FFC template `.linkinatorrc.json`, link checking workflow
-
----
-
-## Tracking and Prioritization
-
-### Priority Levels
-
-**🔴 High Priority (Phase 1 & 5 - Address within 3 months):**
-- Testing infrastructure (critical for quality)
-- Security features and branch protection
-- CI/CD reliability
-
-**🟡 Medium Priority (Phase 2 & 3 - Address within 6 months):**
-- Code quality tools (developer experience)
-- CI/CD enhancements
-- Dependency management
-
-**🟢 Low Priority (Phase 4 & 6 - Address within 12 months):**
-- Documentation improvements
-- Performance monitoring
-- Nice-to-have enhancements
-
----
-
-### Implementation Roadmap
-
-**Quarter 1 (Months 1-3):**
-- [ ] Complete Phase 1: Testing Infrastructure
-- [ ] Start Phase 2: Code Quality Tools
-- [ ] Implement critical Phase 5 items (security)
-
-**Quarter 2 (Months 4-6):**
-- [ ] Complete Phase 2: Code Quality
-- [ ] Complete Phase 3: CI/CD Enhancements
-- [ ] Complete Phase 5: Branch Protection
-
-**Quarter 3 (Months 7-9):**
-- [ ] Complete Phase 4: Documentation
-- [ ] Start Phase 6: Performance Monitoring
-
-**Quarter 4 (Months 10-12):**
-- [ ] Complete Phase 6: Performance
-- [ ] Review and refine all improvements
-- [ ] Update documentation
-
----
-
-### Current Action Items
-
-**Immediate (Next Sprint):**
-- [ ] Set up Jest and write first 3 component tests
-- [ ] Install Prettier and format codebase
-- [ ] Create Dependabot configuration
-- [ ] Enable branch protection rules
-
-**Short Term (Next Quarter):**
-- [ ] Implement Playwright E2E tests
-- [ ] Set up Husky pre-commit hooks
-- [ ] Split CI and Deploy workflows
-- [ ] Add npm audit to CI
-- [ ] Create CODE_QUALITY.md
-
-**Long Term (Next 6-12 Months):**
-- [ ] Implement Lighthouse CI
-- [ ] Add bundle size monitoring
-- [ ] Create comprehensive TESTING.md
-- [ ] Create DEPENDABOT.md guide
-- [ ] Add link validation
-
----
-
-### Review Schedule
-
-**Monthly Review:**
-- Review progress on current phase
-- Assess priority changes
-- Update action items
-- Address blockers
-
-**Quarterly Review:**
-- Re-evaluate phase priorities
-- Plan next quarter's work
-- Update this document
-- Celebrate wins
-
-**Annual Review:**
-- Comprehensive review of all improvements
-- Major refactoring planning
-- Technology stack updates
-- Long-term roadmap
-
----
-
-## Differences from FFC Template (Intentional)
-
-The following items exist in the FFC template but are **not recommended** for KCCF-web:
-
-### 1. EditorConfig
-**FFC Has:** `.editorconfig` file  
-**KCCF Status:** Not needed if Prettier is adopted  
-**Reason:** Prettier handles all formatting; EditorConfig adds redundancy
-
-### 2. Multiple E2E Test Files
-**FFC Has:** Many specific test files  
-**KCCF Status:** Start smaller  
-**Reason:** KCCF-web has fewer pages; can start with fewer tests and expand
-
-### 3. Extensive Documentation Files
-**FFC Has:** 30+ markdown documentation files  
-**KCCF Status:** Adopt selectively  
-**Reason:** Some FFC docs are specific to their use case (Facebook Events, Cloudflare setup, etc.)
-
-### 4. Admin Page Features
-**FFC Has:** JSON-based CMS admin page  
-**KCCF Status:** Not applicable  
-**Reason:** KCCF uses different content management approach (direct code edits)
+1. **EditorConfig** — redundant once Prettier is adopted (2.2 optional).
+2. **Full E2E parity** — KCCF has fewer pages; start with a smoke suite, expand as needed.
+3. **30+ template docs** — adopt selectively; some are FFC-org-specific (Cloudflare, Facebook Events, rebrand tooling like `check:rebrand`).
+4. **`check:rebrand` / JSON CMS admin** — KCCF manages content via direct code edits; not applicable.
 
 ---
 
 ## Related Documentation
 
-- [README.md](./README.md) - Main project documentation
-- [CONTRIBUTING.md](./CONTRIBUTING.md) - Contribution guidelines
-- [SECURITY.md](./SECURITY.md) - Security policies
-- [EXTERNAL_SERVICES.md](./EXTERNAL_SERVICES.md) - Third-party services guide
-- [FFC Template Repository](https://github.com/FreeForCharity/FFC_Single_Page_Template) - Reference repository
+- [README.md](./README.md)
+- [CI_CD_DEPLOYMENT.md](./CI_CD_DEPLOYMENT.md)
+- [CONTRIBUTING.md](./CONTRIBUTING.md)
+- [SECURITY.md](./SECURITY.md)
+- [FFC Template Repository](https://github.com/FreeForCharity/FFC_Single_Page_Template) — reference repository
 
 ---
-
-## Questions or Concerns?
-
-If you have questions about technical debt items or want to propose changes:
-
-- Open a GitHub Discussion
-- Create an issue with label `technical-debt`
-- Contact repository maintainers via [thekccf.org/contact](https://thekccf.org/contact)
-
----
-
-**Document Maintenance:**
-- Update this document when technical debt items are added or resolved
-- Review and update priorities quarterly
-- Keep the action items section current
-- Reference specific commits or PRs that address items

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -39,7 +39,7 @@ KCCF-web is **actively maintained on content and product**, but its **infrastruc
 
 - **Infrastructure adoption vs. plan:** ~0%
 - **Automated tests in KCCF-web:** 0 (verified)
-- **CI jobs in KCCF-web:** build/deploy + CodeQL only (no format, lint-as-gate is present, no tests, no audit, no perf)
+- **CI in KCCF-web:** a `ci` job (lint + explicit `tsc --noEmit` type-check + build) with a separate `deploy` job gated on it, plus CodeQL — but no format check, no tests, no npm audit, no performance checks
 - **Config/quality files adopted:** 0 of ~10
 
 ---
@@ -62,7 +62,7 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 | 3.1 | Husky pre-commit hooks | ✅ `.husky/`, `prepare` script | ❌ | ❌ |
 | 3.2 | Commitlint | ✅ `commitlint.config.js` | ❌ | ❌ |
 | | **CI/CD** | | | |
-| 4.1 | Split CI vs. deploy workflows | ✅ `ci.yml` + `deploy.yml` | 🟡 single `nextjs.yml` (build+deploy combined) | ❌ |
+| 4.1 | Split CI vs. deploy workflows | ✅ `ci.yml` + `deploy.yml` | 🟡 single `nextjs.yml`, but already 2 jobs (`ci` + `deploy` gated on it) | 🟡 |
 | 4.2 | Format check in CI | ✅ `npm run format:check` step | ❌ | ❌ |
 | 4.3 | Lint gate in CI | ✅ | ✅ (lint runs in `nextjs.yml`) | ✅ |
 | 4.4 | Unit tests in CI | ✅ `npm test` (CI=true) | ❌ | ❌ |
@@ -84,7 +84,7 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 | 6.5 | Config-drift check | ✅ `drift-check.yml`, `check:drift` | ❌ | ❌ |
 | 6.6 | Phantom-revert guard | ✅ `phantom-revert-guard.yml` | ❌ | ❌ |
 
-**Score:** KCCF-web meets **2 of 27** tracked infrastructure capabilities (CodeQL, lint-in-CI).
+**Score:** KCCF-web meets **2 of 27** tracked infrastructure capabilities (CodeQL, lint-in-CI), with **4.1 partially met** (CI/deploy already split into two jobs).
 
 ---
 
@@ -95,7 +95,7 @@ Legend: ✅ done · 🟡 partial · ❌ not started
 **`package.json` devDependencies:** `@eslint/eslintrc`, `@tailwindcss/postcss`, `@types/*`, `eslint`, `eslint-config-next`, `tailwindcss`, `typescript`. No test, formatting, hook, or commit-lint tooling.
 
 **`.github/workflows/` (2 files):**
-- `nextjs.yml` — lint → type-check (via build) → build → deploy to GitHub Pages (single combined workflow)
+- `nextjs.yml` — one workflow file, two jobs: a `ci` job (lint → `npx tsc --noEmit` → build) and a `deploy` job (GitHub Pages, `needs: ci`, main only)
 - `codeql.yml` — CodeQL security scanning
 
 **Quality/config files present:** none of `.prettierrc*`, `.editorconfig`, `.nvmrc`, `jest.config.js`, `playwright.config.ts`, `commitlint.config.js`, `.husky/`, `dependabot.yml`, `lighthouserc.json`, `.linkinatorrc.json`.
@@ -171,10 +171,10 @@ Snapshot of the reference template as of July 2026 — this is the moving target
 
 ## Phase 4: CI/CD Pipeline Restructure
 
-**Priority:** 🔴 High · **Impact:** Real quality gate before deploy; today only lint + build gate deploys.
+**Priority:** 🔴 High · **Impact:** Real quality gate before deploy; today only lint + type-check + build gate deploys.
 
-### 4.1 Split CI and Deploy Workflows
-- **Current:** Single `nextjs.yml` combines build + deploy.
+### 4.1 Split CI and Deploy Workflows — 🟡 partially done
+- **Current:** `nextjs.yml` already separates a `ci` job (lint, type-check, build) from a `deploy` job (`needs: ci`, main-only). Remaining gap vs. the template: splitting into distinct workflow *files*.
 - **Target:** `ci.yml` (checks, runs on all PRs, no deploy) + `deploy.yml` (deploy on `main` after CI passes).
 - **Reference:** FFC `ci.yml`, `deploy.yml`.
 


### PR DESCRIPTION
## Summary

Rewrites `TECHNICAL_DEBT.md` as an **infrastructure-only** technical-debt document, refreshed against the **current (July 2026)** state of the reference template [`FreeForCharity/FFC_Single_Page_Template`](https://github.com/FreeForCharity/FFC_Single_Page_Template). The prior version was last updated December 2025 and had drifted out of date on both sides of the comparison.

## Why

KCCF-web is actively maintained on content/product, but its engineering-maturity has stood still since the original audit while the FFC template kept advancing. This doc re-establishes an accurate, verified baseline so the team can prioritize.

## What changed

- **Verified status dashboard** — a **27-row** capability matrix of KCCF-web vs. the FFC template. KCCF-web fully meets **2 of 27** infra capabilities (CodeQL + lint-in-CI), with **4.1 partially met** (`nextjs.yml` already splits `ci` and `deploy` into two jobs); everything else is not started.
- **Verified "zero tests" finding** — documents that the repository has no automated tests of any kind. Verification covered test files, test dirs, framework configs, `package.json` scripts + devDependencies, `package-lock.json`, and CI steps. The lone `@playwright/test` string in the lockfile is an *optional peer dependency declared by Next.js itself* — not a configured test suite.
- **New template capabilities captured** that the Dec-2025 audit predated: accessibility testing (`jest-axe`/`@axe-core/*`), OpenSSF Scorecard, `security.txt` + expiry monitor, bundle-size check, uptime monitoring, config-drift check, and phantom-revert guard.
- **Recommended low-risk-first sequencing** — quick wins → CI gate → testing baseline → E2E/perf → security/governance layer.

## Scope

Documentation only — no code or configuration behavior changes. Individual phases (Prettier, Jest, split CI, Dependabot, etc.) remain to be implemented in follow-up PRs.

## Verification

`npm run lint` / `npm run build` are unaffected (no source changes). The document's KCCF-web status column was verified directly against the working tree, not assumed.